### PR TITLE
Fix get service endpoint function

### DIFF
--- a/SentinelHub/metadata.txt
+++ b/SentinelHub/metadata.txt
@@ -26,6 +26,8 @@ repository=https://github.com/sentinel-hub/sentinelhub-qgis-plugin
 
 # Recommended items:
 changelog=
+    2.0.2
+        - bug fix about getting incorrect data endpoint when using sentinel hub service endpoint
     2.0.1
         - change main `base_url` to CDSE endpoint
         - add drop down menu to choose the `base_url` endpoint.

--- a/SentinelHub/sentinelhub/ogc.py
+++ b/SentinelHub/sentinelhub/ogc.py
@@ -26,7 +26,7 @@ def get_service_uri(settings, layer):
 
 def get_wms_or_wmts_uri(settings, layer):
     """Generates URI for a QGIS WMS or WMTS map layer"""
-    base_url = _get_service_endpoint(settings)
+    base_url = _get_service_endpoint(settings, layer)
     url_params = {
         "showLogo": "false",
         "time": _build_time(settings),
@@ -56,7 +56,7 @@ def get_wms_or_wmts_uri(settings, layer):
 
 def get_wfs_uri(settings, layer):
     """Generates URI for a QGIS WFS vector map layer"""
-    base_url = _get_service_endpoint(settings)
+    base_url = _get_service_endpoint(settings, layer)
     url_params = {
         "srsname": settings.crs,
         "time": _build_time(settings),
@@ -76,7 +76,7 @@ def get_wfs_uri(settings, layer):
 
 def get_wfs_url(settings, layer, bbox_str, time_range, maxcc=None):
     """Generate URL for WFS request from parameters"""
-    base_url = _get_service_endpoint(settings, ServiceType.WFS)
+    base_url = _get_service_endpoint(settings, layer, ServiceType.WFS)
     params = {
         "service": "WFS",
         "version": "2.0.0",
@@ -94,7 +94,7 @@ def get_wfs_url(settings, layer, bbox_str, time_range, maxcc=None):
 
 def get_wcs_url(settings, layer, bbox, crs=None):
     """Generate a URL for WCS request from parameters"""
-    base_url = _get_service_endpoint(settings, ServiceType.WCS)
+    base_url = _get_service_endpoint(settings, layer, ServiceType.WCS)
     params = {
         "service": "wcs",
         "request": "GetCoverage",
@@ -114,9 +114,12 @@ def get_wcs_url(settings, layer, bbox, crs=None):
     return _build_url(base_url, params)
 
 
-def _get_service_endpoint(settings, service_type=None):
+def _get_service_endpoint(settings, layer, service_type=None):
     """A helper function to provide a service endpoint URL"""
-    base_url = settings.base_url
+    if settings.base_url == "https://sh.dataspace.copernicus.eu":
+        base_url = settings.base_url
+    else:
+        base_url = layer.data_source.service_url
     if service_type is None:
         service_type = settings.service_type
     return f"{base_url}/ogc/{service_type.lower()}/{settings.instance_id}"


### PR DESCRIPTION
To fix the reported [issue](https://github.com/sentinel-hub/sentinelhub-qgis-plugin/issues/35), the adjusted script uses the old way to get the data endpoint for sentinel hub endpoint and keep using the base url for cdse enpoint as it was in the latest version.

For future development, we might want to consider adding a dropdown list for data endppint. This will be discussed after Adrian is back.